### PR TITLE
Ensure SSL verification skipping works

### DIFF
--- a/stea/stea_client.py
+++ b/stea/stea_client.py
@@ -1,6 +1,7 @@
 import json
 
 import requests
+import urllib3
 from requests import RequestException
 from requests.exceptions import HTTPError
 
@@ -13,6 +14,15 @@ def date_string(timestamp):
 
 class SteaClient:
     def __init__(self, server):
+
+        # Skip certificate verification as the default https_proxy is set to point to
+        # port 80 on-premise, making this warning hard to avoid by other means.
+        # pylint: disable=no-member
+        # https://github.com/PyCQA/pylint/issues/4584
+        requests.packages.urllib3.disable_warnings(
+            category=urllib3.exceptions.InsecureRequestWarning
+        )
+
         self.server = server
 
     def get_project(self, project_id, project_version, config_date):

--- a/tests/test_stea.py
+++ b/tests/test_stea.py
@@ -5,6 +5,7 @@ from contextlib import ExitStack as does_not_raise
 
 import pytest
 import requests
+import urllib3
 import yaml
 from ecl.summary import EclSum
 from ecl.util.test import TestAreaContext
@@ -96,6 +97,11 @@ def create_case(case="CSV", restart_case=None, restart_step=-1, data_start=None)
 
 def online():
     try:
+        # pylint: disable=no-member
+        # https://github.com/PyCQA/pylint/issues/4584
+        requests.packages.urllib3.disable_warnings(
+            category=urllib3.exceptions.InsecureRequestWarning
+        )
         requests.get(test_server, verify=False)
         return True
     except requests.exceptions.ConnectionError:


### PR DESCRIPTION
verify=False in the requests.get is no longer enough, as an
InsecureRequestWarning is emitted when https_proxy is set to
http://www-proxy.statoil.no:80/

Resolves #54 