### PR TITLE
Use optional dependencies instead of test_requirements

### DIFF
--- a/ci/testkomodo.sh
+++ b/ci/testkomodo.sh
@@ -1,3 +1,3 @@
 install_test_dependencies () {
-  pip install -r test_requirements.txt
+  pip install .[test]
 }


### PR DESCRIPTION
Resolves https://github.com/equinor/fmu-steaclient/issues/81

Failure during onprem testing:
https://github.com/equinor/komodo-releases/actions/runs/7403919759/job/20145685456