### PR TITLE
Let config_date be a date by default

### DIFF
--- a/stea/stea_config.py
+++ b/stea/stea_config.py
@@ -67,7 +67,8 @@ class Profile(BaseModel):
 class SteaConfig(BaseModel):
     model_config = ConfigDict(populate_by_name=True, alias_generator=replace_dash)
     config_date: datetime = Field(
-        description="timestamp: YYYY-MM-DD HH:MM:SS that comes with stea request",
+        description="date or timestamp: YYYY-MM-DD (HH:MM:SS) "
+        "that comes with stea request",
     )
     project_id: int = Field(
         description=(

--- a/tests/stea_input.yml
+++ b/tests/stea_input.yml
@@ -7,7 +7,7 @@ project-version: 1
 # All information in stea is versioned with a timestamp. When we request a
 # calculation we must specify wich date we wish to use to fetch configuration
 # information for assumptions like e.g. the oil price.
-config-date: 2018-07-01 12:00:00
+config-date: 2018-07-01
 
 
 # The stea web client works by *adjusting* the profiles in an existing

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 import copy
-from datetime import datetime
+from datetime import datetime, date
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,9 +28,12 @@ def remove_key(orig_dict, key):
         None,
     ],
 )
-def test_minimal_config(ecl_case, monkeypatch):
+@pytest.mark.parametrize(
+    "config_date", [date(2018, 10, 10), datetime(2018, 10, 10, 12, 0)]
+)
+def test_minimal_config(ecl_case, monkeypatch, config_date):
     valid_config = {
-        "config_date": datetime(2018, 10, 10, 12, 0),
+        "config_date": config_date,
         "project_id": 1234,
         "project_version": 1,
         "ecl_profiles": {"ID1": {"ecl_key": "FOPT"}},


### PR DESCRIPTION
After the port to pydantic, a datetime field can validate a date, improving user experience.

Resolves #39 